### PR TITLE
add homebrew cask

### DIFF
--- a/lumen.rb
+++ b/lumen.rb
@@ -1,0 +1,15 @@
+cask 'lumen' do
+  version '1.0.0'
+  sha256 'd5ad8dea570063860086df09802cde876070ec7b28694f292e0aa3ce333a1ef9'
+
+  url "https://github.com/anishathalye/lumen/releases/download/v#{version}/lumen.zip"
+  name 'Lumen'
+  homepage 'https://github.com/anishathalye/lumen/'
+  license :gpl
+
+  app 'Lumen.app'
+
+  postflight do
+    suppress_move_to_applications key: 'suppressMoveToApplications'
+  end
+end


### PR DESCRIPTION
Allows Lumen to be installed via [Homebrew Cask](https://caskroom.github.io/).

This could be submitted for inclusion to the main Cask recipes repo but also can install lumen current like:

```
brew cask install https://raw.githubusercontent.com/davidhampgonsalves/lumen/master/lumen.rb
```

Oh course that url could point to the main repo after this PR is merged.
