### PR TITLE
Add experimental CoreDisplay API (fixes #26)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ xcuserdata
 *.moved-aside
 DerivedData
 *.xcuserstate
+
+.DS_Store

--- a/Lumen/AppDelegate.m
+++ b/Lumen/AppDelegate.m
@@ -11,6 +11,7 @@
 
 @property (strong, nonatomic) IBOutlet NSMenu *statusMenu;
 @property (strong, nonatomic) IBOutlet NSMenuItem *toggle;
+@property (strong, nonatomic) IBOutlet NSMenuItem *experimental;
 @property (strong, nonatomic) NSStatusItem *statusItem;
 @property (strong, nonatomic) BrightnessController *brightnessController;
 @property (nonatomic, strong) NSTimer *statsTimer;
@@ -29,6 +30,7 @@
     self.brightnessController = [BrightnessController new];
     [self.brightnessController start];
     [self.toggle setTitle:STOP];
+    [self.experimental setTitle:START_EXPERIMENTAL];
 
     send_stats(TELEMETRY_RETRIES);
     self.statsTimer = [NSTimer scheduledTimerWithTimeInterval:TELEMETRY_INTERVAL
@@ -57,6 +59,16 @@
     } else {
         [self.brightnessController start];
         [self.toggle setTitle:STOP];
+    }
+}
+
+- (IBAction)experimentalModeToggle:(id)sender {
+    if (self.brightnessController.isUsingNewAPI) {
+        [self.brightnessController toggleExperimentalMode];
+        [self.experimental setTitle:START_EXPERIMENTAL];
+    } else {
+        [self.brightnessController toggleExperimentalMode];
+        [self.experimental setTitle:STOP_EXPERIMENTAL];
     }
 }
 

--- a/Lumen/AppDelegate.m
+++ b/Lumen/AppDelegate.m
@@ -27,10 +27,19 @@
     [self.statusItem setMenu:self.statusMenu];
     [self.statusItem setHighlightMode:YES];
 
-    self.brightnessController = [BrightnessController new];
+    NSOperatingSystemVersion minimumOSVersionForExperimentalAPI = { .majorVersion = 10, .minorVersion = 12, .patchVersion = 4 };
+    BOOL shouldDefaultToExperimental = [NSProcessInfo.processInfo isOperatingSystemAtLeastVersion:minimumOSVersionForExperimentalAPI];
+
+    if (shouldDefaultToExperimental) {
+        [self.experimental setTitle:STOP_EXPERIMENTAL];
+    } else {
+        [self.experimental setTitle:START_EXPERIMENTAL];
+    }
+
+    self.brightnessController = [[BrightnessController alloc] init:shouldDefaultToExperimental];
     [self.brightnessController start];
     [self.toggle setTitle:STOP];
-    [self.experimental setTitle:START_EXPERIMENTAL];
+
 
     send_stats(TELEMETRY_RETRIES);
     self.statsTimer = [NSTimer scheduledTimerWithTimeInterval:TELEMETRY_INTERVAL

--- a/Lumen/Base.lproj/MainMenu.xib
+++ b/Lumen/Base.lproj/MainMenu.xib
@@ -16,6 +16,7 @@
             <connections>
                 <outlet property="statusMenu" destination="DlN-4E-L4J" id="LYg-5h-Wy8"/>
                 <outlet property="toggle" destination="dzr-55-Pnj" id="yIV-1F-kwr"/>
+                <outlet property="experimental" destination="kOW-Hy-RvD" id="experimental-outlet"/>
             </connections>
         </customObject>
         <customObject id="YLy-65-1bz" customClass="NSFontManager"/>
@@ -31,6 +32,12 @@
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>
                         <action selector="menuActionIgnoreList:" target="Voe-Tx-rLC" id="59a-Yc-Ohg"/>
+                    </connections>
+                </menuItem>
+                <menuItem title="Experimental" id="kOW-Hy-RvD">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <connections>
+                        <action selector="experimentalModeToggle:" target="Voe-Tx-rLC" id="experimental-mode-toggle-action"/>
                     </connections>
                 </menuItem>
                 <menuItem isSeparatorItem="YES" id="uRX-jK-9tO"/>

--- a/Lumen/BrightnessController.h
+++ b/Lumen/BrightnessController.h
@@ -8,6 +8,7 @@
 @property (nonatomic, readonly) BOOL isRunning;
 @property (nonatomic, readonly) BOOL isUsingNewAPI;
 
+- (id)init:(BOOL)shouldUseNewAPI;
 - (void)start;
 - (void)stop;
 - (void)toggleExperimentalMode;

--- a/Lumen/BrightnessController.h
+++ b/Lumen/BrightnessController.h
@@ -6,8 +6,10 @@
 @interface BrightnessController : NSObject
 
 @property (nonatomic, readonly) BOOL isRunning;
+@property (nonatomic, readonly) BOOL isUsingNewAPI;
 
 - (void)start;
 - (void)stop;
+- (void)toggleExperimentalMode;
 
 @end

--- a/Lumen/BrightnessController.m
+++ b/Lumen/BrightnessController.m
@@ -60,7 +60,7 @@
         self.ignoreList = [[IgnoreListController alloc] init];
         self.lastActiveAppURLString = @"";
 
-        self.shouldUseNewApi = false;
+        self.shouldUseNewApi = true;
     }
     return self;
 }
@@ -206,16 +206,9 @@
         typedef double (*getBrightnessFunctionPointer)(UInt32);
         getBrightnessFunctionPointer getBrightnessWithCoreDisplayAPI = CFBundleGetFunctionPointerForName(coreDisplayBundle, CFSTR("CoreDisplay_Display_GetUserBrightness"));
 
-        if (getBrightnessWithCoreDisplayAPI == NULL) {
-            NSLog(@"Error: Null pointer!");
-        } else {
+        if (getBrightnessWithCoreDisplayAPI != NULL) {
             level = (float) getBrightnessWithCoreDisplayAPI(0);
-            if (self.lastSet != level) {
-                NSLog(@"Got new: %f, self.lastSet = %f", level, self.lastSet);
-            }
         }
-    } else {
-        NSLog(@"Failed!");
     }
     return level;
 }
@@ -245,24 +238,14 @@
     CFBundleRef coreDisplayBundle = CFBundleCreate(kCFAllocatorDefault, coreDisplayPath);
 
     if (!coreDisplayBundle) {
-        NSLog(@"Failed!");
         return;
     }
 
     typedef void (*notifyBrightnessFunctionPointer)(UInt32, double);
     notifyBrightnessFunctionPointer notifyBrightnessWithDisplayServicesAPI = CFBundleGetFunctionPointerForName(coreDisplayBundle, CFSTR("DisplayServicesBrightnessChanged"));
 
-    if (notifyBrightnessWithDisplayServicesAPI == NULL) {
-        NSLog(@"Error: Null pointer!");
-    } else {
-        if (level == 0) {
-            NSLog(@"It wants to set to 0...");
-        } else {
-            if (self.lastSet != level) {
-                NSLog(@"NOTIFYING %f", level);
-            }
-            notifyBrightnessWithDisplayServicesAPI(0, (double) level);
-        }
+    if (notifyBrightnessWithDisplayServicesAPI != NULL) {
+        notifyBrightnessWithDisplayServicesAPI(0, (double) level);
     }
 }
 
@@ -271,27 +254,18 @@
     CFBundleRef coreDisplayBundle = CFBundleCreate(kCFAllocatorDefault, coreDisplayPath);
 
     if (!coreDisplayBundle) {
-        NSLog(@"Failed!");
         return;
     }
 
     typedef void (*setBrightnessFunctionPointer)(UInt32, double);
     setBrightnessFunctionPointer setBrightnessWithCoreDisplayAPI = CFBundleGetFunctionPointerForName(coreDisplayBundle, CFSTR("CoreDisplay_Display_SetUserBrightness"));
 
-    if (setBrightnessWithCoreDisplayAPI == NULL) {
-        NSLog(@"Error: Null pointer!");
-    } else {
-        if (level == 0) {
-            NSLog(@"It wants to set to 0...");
-        } else {
-            if (self.lastSet != level) {
-                NSLog(@"Setting to %f, self.lastSet = %f", level, self.lastSet);
-            }
-            setBrightnessWithCoreDisplayAPI(0, (double) level);
-            [self notifySystemOfNewBrightness:level];
-        }
+    if (setBrightnessWithCoreDisplayAPI != NULL) {
+        setBrightnessWithCoreDisplayAPI(0, (double) level);
+        [self notifySystemOfNewBrightness:level];
     }
 }
+
 - (void)setBrightness:(float)level {
     if (self.shouldUseNewApi) {
         [self setBrightnessNewAPI:level];

--- a/Lumen/BrightnessController.m
+++ b/Lumen/BrightnessController.m
@@ -48,7 +48,7 @@
 
 @implementation BrightnessController
 
-- (id)init {
+- (id)init:(BOOL)shouldUseNewAPI {
     self = [super init];
     if (self) {
         self.model = [Model new];
@@ -60,7 +60,7 @@
         self.ignoreList = [[IgnoreListController alloc] init];
         self.lastActiveAppURLString = @"";
 
-        self.isUsingNewAPI = false;
+        self.isUsingNewAPI = shouldUseNewAPI;
     }
     return self;
 }

--- a/Lumen/BrightnessController.m
+++ b/Lumen/BrightnessController.m
@@ -17,7 +17,7 @@
 @property (nonatomic, assign) float lastSet;
 @property (nonatomic, assign) BOOL noticed;
 @property (nonatomic, assign) float lastNoticed;
-@property (nonatomic, assign) BOOL shouldUseNewApi;
+@property (nonatomic, assign) BOOL isUsingNewAPI;
 
 /**
  Flags whether ignore observeOutput:forInput: due to brightness changes in ignored apps.
@@ -60,13 +60,17 @@
         self.ignoreList = [[IgnoreListController alloc] init];
         self.lastActiveAppURLString = @"";
 
-        self.shouldUseNewApi = true;
+        self.isUsingNewAPI = false;
     }
     return self;
 }
 
 - (BOOL)isRunning {
     return self.timer && [self.timer isValid];
+}
+
+- (void)toggleExperimentalMode {
+    self.isUsingNewAPI = !self.isUsingNewAPI;
 }
 
 - (void)start {
@@ -215,7 +219,7 @@
 
 - (float)getBrightness {
     float level = 1.0f;
-    if (self.shouldUseNewApi) {
+    if (self.isUsingNewAPI) {
         level = [self getBrightessNewAPI];
     } else {
         io_iterator_t iterator;
@@ -267,7 +271,7 @@
 }
 
 - (void)setBrightness:(float)level {
-    if (self.shouldUseNewApi) {
+    if (self.isUsingNewAPI) {
         [self setBrightnessNewAPI:level];
     } else {
         io_iterator_t iterator;

--- a/Lumen/Constants.h
+++ b/Lumen/Constants.h
@@ -8,7 +8,7 @@
 #define START (@"Start")
 
 #define START_EXPERIMENTAL (@"Use experimental API")
-#define STOP_EXPERIMENTAL (@"Use standard API")
+#define STOP_EXPERIMENTAL (@"Don't use experimental API")
 
 #define TELEMETRY_URL (@"https://telemetry.anish.io/api/v1/submit")
 #define TELEMETRY_IDENTIFIER (@"lumen-boot")

--- a/Lumen/Constants.h
+++ b/Lumen/Constants.h
@@ -7,6 +7,9 @@
 #define STOP (@"Stop")
 #define START (@"Start")
 
+#define START_EXPERIMENTAL (@"Use experimental API")
+#define STOP_EXPERIMENTAL (@"Use standard API")
+
 #define TELEMETRY_URL (@"https://telemetry.anish.io/api/v1/submit")
 #define TELEMETRY_IDENTIFIER (@"lumen-boot")
 #define TELEMETRY_RETRIES 5

--- a/Lumen/Model.m
+++ b/Lumen/Model.m
@@ -88,7 +88,18 @@
     float prevx = point.x, prevy = point.y;
     for (NSInteger i = index - 1; i >= 0; i--) {
         XYPoint *p = [self.points objectAtIndex:i];
-        if (p.y < prevy || (prevx - p.x) < MIN_X_SPACING || (p.x - prevx) < MIN_X_SPACING) {
+        if (p.y < prevy || (prevx - p.x) < MIN_X_SPACING) {
+            [toDelete addIndex:i];
+        } else {
+            prevx = p.x;
+            prevy = p.y;
+        }
+    }
+    prevx = point.x;
+    prevy = point.y; // reset these
+    for (NSInteger i = index + 1; i < self.points.count; i++) {
+        XYPoint *p = [self.points objectAtIndex:i];
+        if (p.y > prevy || (p.x - prevx) < MIN_X_SPACING) {
             [toDelete addIndex:i];
         } else {
             prevx = p.x;

--- a/Lumen/Model.m
+++ b/Lumen/Model.m
@@ -88,18 +88,7 @@
     float prevx = point.x, prevy = point.y;
     for (NSInteger i = index - 1; i >= 0; i--) {
         XYPoint *p = [self.points objectAtIndex:i];
-        if (p.y < prevy || (prevx - p.x) < MIN_X_SPACING) {
-            [toDelete addIndex:i];
-        } else {
-            prevx = p.x;
-            prevy = p.y;
-        }
-    }
-    prevx = point.x;
-    prevy = point.y; // reset these
-    for (NSInteger i = index + 1; i < self.points.count; i++) {
-        XYPoint *p = [self.points objectAtIndex:i];
-        if (p.y > prevy || (p.x - prevx) < MIN_X_SPACING) {
+        if (p.y < prevy || (prevx - p.x) < MIN_X_SPACING || (p.x - prevx) < MIN_X_SPACING) {
             [toDelete addIndex:i];
         } else {
             prevx = p.x;


### PR DESCRIPTION
This adds an option to use the undocumented private CoreDisplay and DisplayServices APIs to modify brightness, which should resolve issues on Mac OS 10.12.4 and later with brightness reverting.

Main changes:
 - Adds NSMenuItem `experimental` to toggle the use of the new API. This defaults to `true` if OS version is >= 10.12.4.
 - Adds `isUsingNewAPI` and `toggleExperimentalMode` to BrightnessController to manage this state.
 - Adds `getBrightessNewAPI`, `setBrightnessNewAPI`, and `notifySystemOfNewBrightness` to BrightnessController, using code adapted from [fnesveda/ExternalDisplayBrightness](https://github.com/fnesveda/ExternalDisplayBrightness/blob/f87fb7096ee332d071fc7b09730ccccd410131bd/src/ExternalDisplayBrightness/BrightnessManager.swift#L68).

Also:
 - Adds .DS_Store to `.gitignore` to avoid polluting repo.

This works on my MacBookPro16,1 with AMD Radeon Pro 5300M running Mac OS 10.15.7. I'm able to run f.lux without the brightness changes of lumen being reverted after a few seconds (as in #26). @anishathalye I haven't written Objective-C before, and I'm open to any improvements! What do we think?